### PR TITLE
feat: export git user environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ jobs:
 - `org` - *(optional)* The organization for an org-scoped token
 - `owner` - *(optional)* The repository owner for a repo-scoped token
 - `repo` - *(optional)* The repository name for a repo-scoped token
+- `export-git-user` - *(optional)* [Export environment variables][git-env-variables]
+  which set the git user to the GitHub app user
 
 ### Outputs
 
@@ -60,3 +62,4 @@ jobs:
 MIT
 
 [generating-cred-bundle]: https://github.com/electron/github-app-auth#generating-credentials
+[git-env-variables]: https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   repo:
     description: 'The repo name for a repo-scoped token'
     required: false
+  export-git-user:
+    description: 'Export environment variables which set the git user to the GitHub app user'
+    required: false
 
 outputs:
   token:


### PR DESCRIPTION
Currently making a commit in a workflow as a GItHub app requires constructing the email from the app's user ID and username slug, which is tedious to do manually, so offer it as a side effect of this action.