### PR TITLE
fix: set default for export-git-user input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
   export-git-user:
     description: 'Export environment variables which set the git user to the GitHub app user'
     required: false
+    default: false
 
 outputs:
   token:


### PR DESCRIPTION
Without a default here there's an error if you leave the input undefined.