### PR TITLE
build: remove unused js-yaml dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-plugin-prettier": "^5.0.0",
         "husky": "^8.0.3",
         "jest": "^29.6.3",
-        "js-yaml": "^4.1.0",
         "prettier": "^3.0.2",
         "prettier-eslint": "^15.0.1",
         "ts-jest": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "eslint-plugin-prettier": "^5.0.0",
     "husky": "^8.0.3",
     "jest": "^29.6.3",
-    "js-yaml": "^4.1.0",
     "prettier": "^3.0.2",
     "prettier-eslint": "^15.0.1",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
I've also landed this in the upstream template repo, `actions/typescript-action`, that this repo used that template and that's how `js-yaml` ended up here.