### PR TITLE
docs: update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ input.
 jobs:
   issue-commented:
     name: Remove label on comment
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: electron/github-app-auth-action@v1.0.0
+        uses: electron/github-app-auth-action@main
         id: generate-token
         with:
           creds: ${{ secrets.GH_APP_CREDS }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: electron/github-app-auth-action@main
+        uses: electron/github-app-auth-action@v1.1.1
         id: generate-token
         with:
           creds: ${{ secrets.GH_APP_CREDS }}


### PR DESCRIPTION
Copy and paste mistake in the example, it doesn't need the `permissions` key since it's using the generated token. Also switches to using `@main` rather than an outdated version tag.