### PR TITLE
ci: use electron/semantic-trusted-release instead of npx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,15 @@ jobs:
     needs: test-typescript
     if: github.ref == 'refs/heads/main'
     permissions:
-      contents: write
+      contents: write # for making github release
+      pull-requests: write # for commenting release version
+      issues: write # for commenting release version
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20
-      - run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Run semantic release
+        uses: electron/semantic-trusted-release@03517840010ba30fe5264f4875f4cff066b658d1 # v1.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces unpinned `npx semantic-release` with the org-standard `electron/semantic-trusted-release` composite action.

**The problem:**
```yaml
- run: npx semantic-release  # ← fetches @latest from registry, no pin, no local dep
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
This fetches `semantic-release@latest` from npm on every release run, with `GITHUB_TOKEN` (contents: write) in scope. A compromised semantic-release release would get code execution with push-tag/create-release privileges.

**The fix:**
`electron/semantic-trusted-release` installs semantic-release from a frozen `yarn.lock` — same pattern already used by 26 other repos in the org (`secret-service-action` is the closest analog since it's also a GitHub Action, not an npm package).

The existing `.releaserc.json` is already identical to `secret-service-action`'s — just `commit-analyzer` / `release-notes-generator` / `@semantic-release/github`, all bundled with semantic-release core. No config changes needed.

**Also in this PR:**
- Dropped the redundant setup-node step — the composite action brings its own pinned Node
- Added `persist-credentials: false` on checkout (semantic-release uses the passed-in token, not checkout creds)
- Added `pull-requests: write` / `issues: write` permissions so semantic-release can comment on linked PRs/issues with the release version