### PR TITLE
ci: replace super-linter with yarn lint and format:check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  statuses: write
 
 jobs:
   lint:
@@ -20,31 +18,19 @@ jobs:
 
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
-        id: setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           cache: yarn
 
       - name: Install Dependencies
-        id: install
         run: yarn install --immutable
 
-      - name: Lint Codebase
-        id: super-linter
-        uses: super-linter/super-linter/slim@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
-        env:
-          DEFAULT_BRANCH: main
-          FILTER_REGEX_EXCLUDE: dist/**/*
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TYPESCRIPT_DEFAULT_STYLE: prettier
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_JAVASCRIPT_STANDARD: false
-          VALIDATE_JSCPD: false
-          VALIDATE_TYPESCRIPT_STANDARD: false
+      - name: Check Format
+        run: yarn format:check
+
+      - name: Lint
+        run: yarn lint


### PR DESCRIPTION
Drops the super-linter action in favour of running `yarn format:check` and `yarn lint` directly, which matches the scripts already defined in this repo and removes the need for the `packages: read` and `statuses: write` permissions on the lint workflow.